### PR TITLE
:sparkles: Normalize strings representation

### DIFF
--- a/phpunit-tests/HelloWorldTest.php
+++ b/phpunit-tests/HelloWorldTest.php
@@ -25,7 +25,7 @@ class HelloWorldTest extends RepresenterTest
         $this->assertEquals(<<<'EOF'
         function fn0()
         {
-            return "Hello World!";
+            return 'Hello World!';
         }
         EOF
         , $result);

--- a/phpunit-tests/StringTest.php
+++ b/phpunit-tests/StringTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use function var_export;
+
+/**
+ * @see https://www.php.net/manual/en/language.types.string.php
+ *
+ * We will convert all strings to singlequotes as reported by `var_export()`
+ */
+class StringTest extends RepresenterTest
+{
+    public function testDoubleQuotes(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            "test";
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'EOF'
+            'test';
+            EOF,
+            '{}',
+        );
+    }
+
+    public function testDoubleQuotesWithEscapes(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            "\n\r\n\t\n\v\n\e\n\f\n\\\n\$\n\"\n\377\n\x26\n\u2665";
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            var_export("\n\r\n\t\n\v\n\e\n\f\n\\\n\$\n\"\n\377\n\x26\n\u2665", true) . ';',
+            '{}',
+        );
+    }
+
+    public function testDoubleQuotesEncapsulation(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            "encapsed $a or ${a}.";
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'EOF'
+            'encapsed ' . $v0 . ' or ' . $v0 . '.';
+            EOF,
+            '{"v0":"a"}',
+        );
+    }
+
+    public function testDoubleQuotesSimpleEncapsulation(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            "$a";
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'EOF'
+            $a;
+            EOF,
+            '{}',
+        );
+    }
+
+    public function testHeredoc(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            <<<EOT
+            test
+            EOT;
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'EOF'
+            'test';
+            EOF,
+            '{}',
+        );
+    }
+
+    public function testHeredocWithEscapes(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            <<<EOT
+            Test "$a"\x41.
+            EOT;
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'EOF'
+            'Test "' . $v0 . '"A.';
+            EOF,
+            '{"v0":"a"}',
+        );
+    }
+
+    public function testNowdoc(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            <<<'EOD'
+            test
+            EOD;
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'EOF'
+            'test';
+            EOF,
+            '{}',
+        );
+    }
+
+    public function testUselessConcatenation(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            'test' . 'test' . 'test';
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'EOF'
+            'testtesttest';
+            EOF,
+            '{}',
+        );
+    }
+
+    public function testUselessRightConcatenation(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            'test' . ('test' . 'test');
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'EOF'
+            'testtesttest';
+            EOF,
+            '{}',
+        );
+    }
+}

--- a/phpunit-tests/StripCommentTest.php
+++ b/phpunit-tests/StripCommentTest.php
@@ -24,11 +24,11 @@ class StripCommentTest extends RepresenterTest
         $this->assertRepresentation(
             $code,
             <<<'EOF'
-        function fn0()
-        {
-            return "Hello World!";
-        }
-        EOF,
+            function fn0()
+            {
+                return 'Hello World!';
+            }
+            EOF,
             '{"fn0":"helloworld"}',
         );
     }


### PR DESCRIPTION
Fixes #2

After this pull request the repartition of solutions for `hello-world` will be:
```
$ find ./solutions ! -empty -type f -name representation.txt -exec md5sum {} + | sort | uniq -w32 -c | sed 's@^[^0-9]*\([0-9]\+\).*@\1@' | sort -n | uniq -c
      8 1   # There are still 8 unique (1) solution, looking at those none of them could be integrated in the other groups
      2 3   # There are 2 groups: one with typing, the other one with code re-ordering
      1 28  # This group of 28 solutions is legit (the function is called and echo-ed)
      1 38  # This group of 38 solutions is legit (the function is called)
      1 420 # The most common solution has 420 candidate with the representer
```