### PR TITLE
:sparkles: Normalize internal method aliases

### DIFF
--- a/phpunit-tests/FunctionMappingTest.php
+++ b/phpunit-tests/FunctionMappingTest.php
@@ -123,4 +123,47 @@ class FunctionMappingTest extends RepresenterTestCase
             '{"fn0":"a","v0":"a"}',
         );
     }
+
+    public function testReplacesFunctionAliases(): void
+    {
+        $code = <<<'CODE'
+            <?php
+            chop();
+            doubleval();
+            fputs();
+            ini_alter();
+            is_double();
+            is_integer();
+            is_long();
+            is_writeable();
+            join();
+            key_exists();
+            pos();
+            show_source();
+            sizeof();
+            strchr();
+            CODE;
+
+        $this->assertRepresentation(
+            $code,
+            <<<'CODE'
+            rtrim();
+            floatval();
+            fwrite();
+            ini_set();
+            is_float();
+            is_int();
+            is_int();
+            is_writable();
+            implode();
+            array_key_exists();
+            current();
+            highlight_file();
+            count();
+            strstr();
+            CODE,
+            // phpcs:ignore Generic.Files.LineLength -- Not worth splitting into multiple lines
+            '{"array_key_exists":"key_exists","count":"sizeof","current":"pos","floatval":"doubleval","fwrite":"fputs","highlight_file":"show_source","implode":"join","ini_set":"ini_alter","is_float":"is_double","is_int":"is_long","is_writable":"is_writeable","rtrim":"chop","strstr":"strchr"}',
+        );
+    }
 }

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -55,13 +55,46 @@ class Mapping
         return json_encode($mapping, JSON_FORCE_OBJECT | JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
     }
 
+    /**
+     * TRANSFORM: normalize PHP's aliased function names (only Base syntax)
+     *
+     * @see https://www.php.net/manual/en/aliases.php
+     */
+    private function functionAlias(string $name): string
+    {
+        return match ($name) {
+            'chop' => 'rtrim',
+            // 'close' => 'closedir', // close() does not exist in PHP 8.0 (no documentation)
+            'doubleval' => 'floatval',
+            'fputs' => 'fwrite',
+            'ini_alter' => 'ini_set',
+            'is_double' => 'is_float',
+            'is_integer' => 'is_int',
+            'is_long' => 'is_int',
+            // 'is_real' => 'is_float', // is_real() is removed in PHP 8.0
+            'is_writeable' => 'is_writable',
+            'join' => 'implode',
+            'key_exists' => 'array_key_exists',
+            'pos' => 'current',
+            'show_source' => 'highlight_file',
+            'sizeof' => 'count',
+            'strchr' => 'strstr',
+            default => $name,
+        };
+    }
+
     public function addFunction(string $name): string
     {
         // TRANSFORM: Function names are case-insensitive in PHP
         $name = mb_strtolower($name);
-        // Do not rename built-in functions, functions_exists() includes user-defined functions
+        // Do not rename built-in functions except aliased ones, functions_exists() includes user-defined functions
         if (array_key_exists($name, $this->internalFunctions)) {
-            return $name;
+            $unaliasedName = $this->functionAlias($name);
+            if ($unaliasedName !== $name) {
+                $this->invertedFunctionMapping[$name] = $unaliasedName;
+            }
+
+            return $unaliasedName;
         }
 
         if (! isset($this->invertedFunctionMapping[$name])) {


### PR DESCRIPTION
Some community solutions use aliased functions instead of the base ones. Let's normalize those solutions.