### PR TITLE
:bug: Case-insensitiveness is only for A-Z char

### DIFF
--- a/phpunit-tests/ClassMappingTest.php
+++ b/phpunit-tests/ClassMappingTest.php
@@ -43,8 +43,8 @@ class ClassMappingTest extends RepresenterTestCase
         // ΤΑΞΗ (uppercase) and ταξη (lowercase) means "class" in Greek
         $code = <<<'CODE'
             <?php
-            class ΤΑΞΗ {}
-            new ταξη();
+            class AΤΑΞΗ {}
+            new aΤΑΞΗ();
             CODE;
 
         $this->assertRepresentation($code, <<<'CODE'
@@ -52,7 +52,7 @@ class ClassMappingTest extends RepresenterTestCase
         {
         }
         new C0();
-        CODE, '{"C0":"ΤΑΞΗ"}');
+        CODE, '{"C0":"AΤΑΞΗ"}');
     }
 
     public function testCaseInsensitiveMultipleOccurrences(): void

--- a/phpunit-tests/FunctionMappingTest.php
+++ b/phpunit-tests/FunctionMappingTest.php
@@ -70,8 +70,8 @@ class FunctionMappingTest extends RepresenterTestCase
         // ΛΕΙΤΟΥΡΓΙΑ (uppercase) and λειτουργια (lowercase) means "function" in Greek
         $code = <<<'CODE'
             <?php
-            function ΛΕΙΤΟΥΡΓΙΑ() {}
-            λειτουργια();
+            function AΛΕΙΤΟΥΡΓΙΑ() {}
+            aΛΕΙΤΟΥΡΓΙΑ();
             CODE;
 
         $this->assertRepresentation(
@@ -82,7 +82,7 @@ class FunctionMappingTest extends RepresenterTestCase
             }
             fn0();
             CODE,
-            '{"fn0":"ΛΕΙΤΟΥΡΓΙΑ"}',
+            '{"fn0":"AΛΕΙΤΟΥΡΓΙΑ"}',
         );
     }
 

--- a/phpunit-tests/MethodMappingTest.php
+++ b/phpunit-tests/MethodMappingTest.php
@@ -37,10 +37,10 @@ class MethodMappingTest extends RepresenterTestCase
         $code = <<<'CODE'
             <?php
             class A {
-                public static function ΜΕΘΟΔΟΣ() {}
+                public static function AΜΕΘΟΔΟΣ() {}
             }
             
-            A::μεθοδοσ();
+            A::aΜΕΘΟΔΟΣ();
             CODE;
 
         $this->assertRepresentation($code, <<<'CODE'
@@ -51,7 +51,7 @@ class MethodMappingTest extends RepresenterTestCase
             }
         }
         C0::m0();
-        CODE, '{"C0":"A","m0":"ΜΕΘΟΔΟΣ"}');
+        CODE, '{"C0":"A","m0":"AΜΕΘΟΔΟΣ"}');
     }
 
     public function testPublicModifier(): void

--- a/src/Mapping.php
+++ b/src/Mapping.php
@@ -10,7 +10,7 @@ use function count;
 use function get_defined_functions;
 use function json_encode;
 use function ksort;
-use function mb_strtolower;
+use function strtolower;
 
 use const JSON_FORCE_OBJECT;
 use const JSON_THROW_ON_ERROR;
@@ -95,7 +95,7 @@ class Mapping
     public function addFunction(string $name): string
     {
         // TRANSFORM: Function names are case-insensitive in PHP
-        $lcName = mb_strtolower($name);
+        $lcName = strtolower($name);
         $entry = $this->invertedFunctionMapping[$lcName] ?? null;
         if ($entry === null) {
             // Do not rename built-in functions except aliased ones, functions_exists() includes user-defined functions
@@ -133,7 +133,7 @@ class Mapping
     public function addClass(string $name): string
     {
         // TRANSFORM: Class names are case-insensitive in PHP
-        $lcName = mb_strtolower($name);
+        $lcName = strtolower($name);
         $entry = $this->invertedClassMapping[$lcName]
             ??= new MappingEntry(self::CLASS_PREFIX . count($this->invertedClassMapping));
         $entry->addValue($name);
@@ -144,7 +144,7 @@ class Mapping
     public function addMethod(string $name): string
     {
         // TRANSFORM: Method names are case-insensitive in PHP
-        $lcName = mb_strtolower($name);
+        $lcName = strtolower($name);
         $entry = $this->invertedMethodMapping[$lcName]
             ??= new MappingEntry(self::METHOD_PREFIX . count($this->invertedMethodMapping));
         $entry->addValue($name);


### PR DESCRIPTION
See https://www.php.net/manual/en/functions.user-defined.php

> Function names are case-insensitive for the ASCII characters A to Z

Tested in PHP8.3 interpreter for class, functions and methods and they are all case-insensitive only for the A-Z char.

While this technically change the representation it is very unlikely that it affects any representation. Affected representation would use utf-8 in their symbol names with uppercase and lowercase defining different symbol. So I did not increment the version.