### PR TITLE
:sparkles: Normalize "typed class constants" by removing them

### DIFF
--- a/phpunit-tests/ClassTest.php
+++ b/phpunit-tests/ClassTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+class ClassTest extends RepresenterTestCase
+{
+    public function testClassConstantType(): void
+    {
+        $this->assertSameRepresentation(
+            <<<'CODE'
+            <?php
+            interface I {
+                const string PHP = 'PHP 8.3';
+            }
+            
+            class Php84 implements I {
+                const string PHP = 'PHP 8.4';
+            }
+            CODE,
+            <<<'CODE'
+            <?php
+            interface I {
+                const PHP = 'PHP 8.3';
+            }
+            
+            class Php84 implements I {
+                const PHP = 'PHP 8.4';
+            }
+            CODE,
+        );
+    }
+}

--- a/src/NormalizeNodeVisitor.php
+++ b/src/NormalizeNodeVisitor.php
@@ -21,6 +21,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\InterpolatedString;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\InlineHTML;
@@ -250,6 +251,14 @@ class NormalizeNodeVisitor extends NodeVisitorAbstract
     }
 
     /**
+     * TRANSFORM: remove class const type
+     */
+    private function removeClassConstType(ClassConst $node): void
+    {
+        $node->type = null;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function enterNode(Node $node)
@@ -283,6 +292,8 @@ class NormalizeNodeVisitor extends NodeVisitorAbstract
             $this->replaceStaticCallName($node);
         } elseif ($node instanceof MethodCall) {
             $this->replaceMethodCallName($node);
+        } elseif ($node instanceof ClassConst) {
+            $this->removeClassConstType($node);
         }
 
         return null;


### PR DESCRIPTION
(based on #298)

Suggested in #155